### PR TITLE
Feature/default studyplan

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import setup_signal, save_user_info, rules_set, units
+from .views import setup_signal, save_user_info, rules_set, units, default_plan
 
 
 urlpatterns = [
@@ -10,4 +10,5 @@ urlpatterns = [
     #restfule APIs providing ruleset and units.
     path('ruleset/<str:ruleset_code>', view=rules_set, name="rule_set"),
     path('units/<str:unit_codes>', view=units, name="units"),
+    path('plan/<str:ruleset_code>/<str:start>/<str:specialisation>/', view=default_plan, name="default_plan"),
 ]

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -10,5 +10,5 @@ urlpatterns = [
     #restfule APIs providing ruleset and units.
     path('ruleset/<str:ruleset_code>', view=rules_set, name="rule_set"),
     path('units/<str:unit_codes>', view=units, name="units"),
-    path('plan/<str:ruleset_code>/<str:start>/<str:specialisation>/', view=default_plan, name="default_plan"),
+    path('plan/<str:ruleset_code>/<str:start>/<str:specialisation>', view=default_plan, name="default_plan"),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,7 +1,7 @@
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 import json
-from util.config_manager import get_ruleset, get_units
+from util.config_manager import get_ruleset, get_units, get_default_plan
 
 def setup_signal(request):
     return JsonResponse({"message": "UWA Study Planner, Backend communication good!"})
@@ -29,3 +29,8 @@ def units(request, unit_codes):
     units = get_units(codes)
     # units is guaranteed to be non-None
     return JsonResponse(units)
+
+
+def default_plan(request, ruleset_code, start, specialisation):
+    return JsonResponse(get_default_plan(ruleset_code, start, specialisation))
+

--- a/backend/config/default_plans.json
+++ b/backend/config/default_plans.json
@@ -1,0 +1,54 @@
+{
+    "MIT-2025-25S1-ai": {
+        "programme_code": "MIT",
+        "ruleset_code": "MIT-2025",
+        "start": "25S1",
+        "validated": false,
+        "specialisation": "ai",
+        "plan": [
+            {"semester": "25S1", "units": ["CITS1003", "CITS1401", "CITS1402", "PHIL4100"]},
+            {"semester": "25S2", "units": ["CITS2002", "CITS4012"]},
+            {"semester": "26S1", "units": ["CITS4401", "CITS5505", "CITS5508", "CITS4404"]},
+            {"semester": "26S2", "units": ["CITS5206", "CITS5017"]}
+        ]
+    },
+    "MIT-2025-25S2-ai": {
+        "programme_code": "MIT",
+        "ruleset_code": "MIT-2025",
+        "start": "25S2",
+        "validated": false,
+        "specialisation": "ai",
+        "plan": [
+            {"semester": "25S2", "units": ["CITS1003", "CITS1401", "CITS1402", "PHIL4100"]},
+            {"semester": "26S1", "units": ["CITS2005", "CITS5505", "CITS4401", "CITS5508"]},
+            {"semester": "26S2", "units": ["CITS4012", "CITS5017"]},
+            {"semester": "27S1", "units": ["CITS5206", "CITS4404"]}
+        ]
+    },
+    "MIT-2025-25S1-ss": {
+        "programme_code": "MIT",
+        "ruleset_code": "MIT-2025",
+        "start": "25S1",
+        "validated": false,
+        "specialisation": "ss",
+        "plan": [
+            {"semester": "25S1", "units": ["CITS1003", "CITS1401", "CITS1402", "PHIL4100"]},
+            {"semester": "25S2", "units": ["CITS2002"]},
+            {"semester": "26S1", "units": ["CITS4401", "CITS5505", "CITS5506"]},
+            {"semester": "26S2", "units": ["CITS5206", "CITS5507", "CITS5501", "CITS5503"]}
+        ]
+    },
+    "MIT-2025-25S2-ss": {
+        "programme_code": "MIT",
+        "ruleset_code": "MIT-2025",
+        "start": "25S2",
+        "validated": false,
+        "specialisation": "ss",
+        "plan": [
+            {"semester": "25S2", "units": ["CITS1003", "CITS1401", "CITS1402", "PHIL4100"]},
+            {"semester": "26S1", "units": ["CITS2005", "CITS5505", "CITS4401", "CITS5506"]},
+            {"semester": "26S2", "units": ["CITS5501", "CITS5503", "CITS5507"]},
+            {"semester": "27S1", "units": ["CITS5206"]}
+        ]
+    }
+}


### PR DESCRIPTION
### Design of study plan data structure, management in the backend

Please refer to `backend/config/default_plans.json`

### API for load a default study plan along

- url pattern: `plan/<str:ruleset_code>/<str:start>/<str:specialisation>` 

- e.g. `http://localhost:8000/api/plan/MIT-2025/25S2/s`

- sample response :

  ```
  {
    "programme_code": "MIT",
    "ruleset_code": "MIT-2025",
    "start": "25S2",
    "validated": false,
    "specialisation": "ss",
    "plan": [
      {
        "semester": "25S2",
        "units": [
          "CITS1003",
          "CITS1401",
          "CITS1402",
          "PHIL4100"
        ]
      },
      {
        "semester": "26S1",
        "units": [
          "CITS2005",
          "CITS5505",
          "CITS4401",
          "CITS5506"
        ]
      },
      {
        "semester": "26S2",
        "units": [
          "CITS5501",
          "CITS5503",
          "CITS5507"
        ]
      },
      {
        "semester": "27S1",
        "units": [
          "CITS5206"
        ]
      }
    ]
  }
  ```

### Support for detailed unit information when loading a ruleset

- Changes made for api `ruleset/<str:ruleset_code>`
  - `units`: now is a list of detailed unit objs
  - `unit_codes`: new property, same content with former `units`

