### PR TITLE
Fix and extend study plan support for MDS 2024/2025 and MIT 2024

### DIFF
--- a/backend/config/default_plans.json
+++ b/backend/config/default_plans.json
@@ -77,7 +77,7 @@
             {"semester": "27S1", "units": ["CITS5206"]}
         ]
     },
-    "MDS-2025-25S1": {
+    "MDS-2025-25S1-none": {
         "programme_code": "MDS",
         "ruleset_code": "MDS-2025",
         "start": "25S1",
@@ -90,7 +90,7 @@
             {"semester": "26S2", "units": ["CITS5553", "STAT4066", "CITS4012"]}
         ]
     },
-    "MDS-2025-25S2": {
+    "MDS-2025-25S2-none": {
         "programme_code": "MDS",
         "ruleset_code": "MDS-2025",
         "start": "25S2",
@@ -103,7 +103,7 @@
             {"semester": "27S1", "units": ["STAT4064", "CITS5508"]}
         ]
     },
-    "MDS-2024-24S1": {
+    "MDS-2024-24S1-none": {
         "programme_code": "MDS",
         "ruleset_code": "MDS-2024",
         "start": "24S1",
@@ -116,7 +116,7 @@
             {"semester": "25S2", "units": ["CITS5553", "STAT4066", "CITS4012"]}
         ]
     },
-    "MDS-2024-24S2": {
+    "MDS-2024-24S2-none": {
         "programme_code": "MDS",
         "ruleset_code": "MDS-2024",
         "start": "24S2",
@@ -129,7 +129,7 @@
             {"semester": "26S1", "units": ["STAT4064", "CITS5508"]}
         ]
     },
-    "MIT-2024-24S1": {
+    "MIT-2024-24S1-none": {
         "programme_code": "MIT",
         "ruleset_code": "MIT-2024",
         "start": "24S1",
@@ -142,7 +142,7 @@
             {"semester": "25S2", "units": ["CITS5501", "CITS5503", "CITS5206"]}
         ]
     },
-    "MIT-2024-24S2": {
+    "MIT-2024-24S2-none": {
         "programme_code": "MIT",
         "ruleset_code": "MIT-2024",
         "start": "24S2",

--- a/frontend/src/components/CourseSchedule.js
+++ b/frontend/src/components/CourseSchedule.js
@@ -4,56 +4,28 @@ import axios from 'axios';
 import './CourseSchedule.css';
 
 function CourseSchedule() {
-  // Retrieve passed state from the previous page via React Router
   const location = useLocation();
   const initialState = location.state || {};
 
-  // Initialize user input states
   const [name] = useState(initialState.name || '');
   const [year, setYear] = useState(initialState.year || '2025');
   const [semester, setSemester] = useState(initialState.semester || 'S1');
   const [course, setCourse] = useState(initialState.course || 'MIT');
   const [specialisation, setSpecialisation] = useState(initialState.specialisation || 'Software Systems');
 
-  // Data states for course rules and study plan fetched from API
   const [courseRules, setCourseRules] = useState(null);
   const [studyPlan, setStudyPlan] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  /**
-   * Convert specialisation full name to API key.
-   * e.g., "Software Systems" -> "ss"
-   */
-  const getSpecKey = (spec) =>
-    spec.toLowerCase().split(' ').map(word => word[0]).join('');
-
-  /**
-   * Construct the ruleset code based on selected course and year.
-   * e.g., "MIT" and "2025" -> "MIT-2025"
-   */
+  const getSpecKey = (spec) => spec.toLowerCase().split(' ').map(word => word[0]).join('');
   const getRulesetCode = () => `${course}-${year}`;
-
-  /**
-   * Construct starting semester code.
-   * e.g., "2025" and "S1" -> "25S1"
-   */
   const getStartCode = () => year.slice(2) + semester;
 
-  /**
-   * Construct the API URL for fetching study plan data.
-   * If specialisation is applicable (MIT 2025), include it in the URL.
-   */
   const getPlanApiUrl = () => {
-    const baseUrl = `http://localhost:8000/api/plan/${getRulesetCode()}/${getStartCode()}`;
-    if (year === '2025' && course === 'MIT') {
-      return `${baseUrl}/${getSpecKey(specialisation)}`;
-    }
-    return baseUrl;
+    const specKey = (year === '2025' && course === 'MIT') ? getSpecKey(specialisation) : 'none';
+    return `http://localhost:8000/api/plan/${getRulesetCode()}/${getStartCode()}/${specKey}`;
   };
 
-  /**
-   * Fetch course ruleset data whenever year or course changes.
-   */
   useEffect(() => {
     axios.get(`http://localhost:8000/api/ruleset/${getRulesetCode()}`)
       .then(res => setCourseRules(res.data))
@@ -63,9 +35,6 @@ function CourseSchedule() {
       });
   }, [year, course]);
 
-  /**
-   * Fetch study plan data whenever relevant user selections change.
-   */
   useEffect(() => {
     setLoading(true);
     axios.get(getPlanApiUrl())
@@ -80,10 +49,6 @@ function CourseSchedule() {
       .finally(() => setLoading(false));
   }, [year, course, semester, specialisation]);
 
-  /**
-   * Extract all semester labels from the study plan data
-   * and sort them in ascending order.
-   */
   const semesterLabels = studyPlan && studyPlan.plan
     ? [...new Set(studyPlan.plan.map(s => s.semester))].sort()
     : [];
@@ -91,7 +56,6 @@ function CourseSchedule() {
   return (
     <div className="schedule-page">
 
-      {/* Top filter bar for selecting year, semester, course, and specialisation */}
       <div className="filter-bar">
         <div className="filter-group">
           <label>Year:</label>
@@ -117,7 +81,6 @@ function CourseSchedule() {
           </select>
         </div>
 
-        {/* Specialisation selection appears only for MIT 2025 */}
         {year === "2025" && course === "MIT" && (
           <div className="filter-group">
             <label>Specialisation:</label>
@@ -130,11 +93,8 @@ function CourseSchedule() {
         )}
       </div>
 
-      {/* Main course schedule display */}
       <div className="schedule-container">
         <h2>Course Schedule for {name}</h2>
-
-        {/* Display selected information */}
         <div className="schedule-info">
           <p><strong>Year:</strong> {year}</p>
           <p><strong>Starting Semester:</strong> {semester}</p>
@@ -144,72 +104,64 @@ function CourseSchedule() {
           )}
         </div>
 
-        {/* Loading indicator or error message */}
         {loading ? (
           <p>Loading study plan...</p>
         ) : !studyPlan ? (
           <p>No study plan data available.</p>
         ) : (
-          // Study plan table
-        <div className="schedule-table-wrapper">  
-          <table className="schedule-table">
-            <thead>
-              <tr>
-                <th>Semester</th>
-                <th>Course 1</th>
-                <th>Course 2</th>
-                <th>Course 3</th>
-                <th>Course 4</th>
-              </tr>
-            </thead>
-            <tbody>
-              {/* Generate a row for each semester */}
-              {semesterLabels.map(sem => (
-                <tr key={sem}>
-                  <td><strong>{sem}</strong></td>
-                  {/* For each unit in the semester, display its code and name */}
-                  {
-                    (studyPlan.plan.find(s => s.semester === sem)?.units || []).map((unit, i) => {
-                      // Lookup course name from courseRules sections
-                      let courseName = '';
-                      for (const section of Object.values(courseRules.sections || {})) {
-                        const found = section.units.find(u => u.code === unit);
-                        if (found) {
-                          courseName = found.name;
-                          break;
-                        }
-                      }
-                      // If not found, check specialisation units
-                      if (!courseName && year === "2025" && course === "MIT") {
-                        const specUnits = courseRules.specialisations?.[getSpecKey(specialisation)]?.units || [];
-                        const found = specUnits.find(u => u.code === unit);
-                        if (found) {
-                          courseName = found.name;
-                        }
-                      }
-                      return (
-                        <td key={i}>
-                          {unit} {courseName ? `- ${courseName}` : ''}
-                        </td>
-                      );
-                    })
-                  }
-                  {/* Fill empty cells if fewer than 4 units */}
-                  {Array.from({ length: 4 - (studyPlan.plan.find(s => s.semester === sem)?.units.length || 0) }).map((_, idx) => (
-                    <td key={`empty-${idx}`}>-</td>
-                  ))}
+          <div className="schedule-table-wrapper">
+            <table className="schedule-table">
+              <thead>
+                <tr>
+                  <th>Semester</th>
+                  <th>Course 1</th>
+                  <th>Course 2</th>
+                  <th>Course 3</th>
+                  <th>Course 4</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>    
+              </thead>
+              <tbody>
+                {semesterLabels.map(sem => (
+                  <tr key={sem}>
+                    <td><strong>{sem}</strong></td>
+                    {
+                      (studyPlan.plan.find(s => s.semester === sem)?.units || []).map((unit, i) => {
+                        let courseName = '';
+                        for (const section of Object.values(courseRules?.sections || {})) {
+                          const found = section.units.find(u => u.code === unit);
+                          if (found) {
+                            courseName = found.name;
+                            break;
+                          }
+                        }
+                        if (!courseName && year === "2025" && course === "MIT") {
+                          const specUnits = courseRules.specialisations?.[getSpecKey(specialisation)]?.units || [];
+                          const found = specUnits.find(u => u.code === unit);
+                          if (found) {
+                            courseName = found.name;
+                          }
+                        }
+                        return (
+                          <td key={i}>
+                            {unit} {courseName ? `- ${courseName}` : ''}
+                          </td>
+                        );
+                      })
+                    }
+                    {Array.from({ length: 4 - (studyPlan.plan.find(s => s.semester === sem)?.units.length || 0) }).map((_, idx) => (
+                      <td key={`empty-${idx}`}>-</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
 
-      {/* Display optional units and specialisation units */}
-      {courseRules && (
+      {/* Optional and specialisation units display */}
+      {courseRules && studyPlan && (
         <div className="alt-courses-container">
-          {/* List core and elective units by section */}
           {courseRules.sections && Object.keys(courseRules.sections).map((key, i) => (
             <div key={i}>
               <h3>{courseRules.sections[key].name}</h3>
@@ -223,8 +175,6 @@ function CourseSchedule() {
               </ul>
             </div>
           ))}
-
-          {/* List specialisation-specific units if applicable */}
           {year === "2025" && course === "MIT" && courseRules.specialisations && (
             <div>
               <h3>{courseRules.specialisations[getSpecKey(specialisation)]?.name}</h3>


### PR DESCRIPTION
### Summary

This PR introduces several key fixes and improvements:

1. **Added and updated default plans (`default_plans.json`)**
   - Added default plans for:
     - `MDS-2024`
     - `MDS-2025`
     - `MIT-2024`
   - All default plans without specialisations now use `"specialisation": "none"`

2. **Frontend logic update (`CourseSchedule.js`)**
   - Unified all plan API calls to use 3-part path:
     `/api/plan/<ruleset_code>/<start>/<specialisation>`
   - For MIT-2025, the actual specialisation (`ai`, `ss`, `ac`) is passed.
   - For all others, `"none"` is passed to avoid 404 errors.

### Test

All plans including:
- MIT-2024/2025 (with & without specialisations)
- MDS-2024/2025

...have been tested successfully on local dev environment (`localhost:3000`).

---

✅ Ready for review.
