### PR TITLE
Add import/export study plan feature

### DIFF
--- a/frontend/src/components/CourseSchedule.css
+++ b/frontend/src/components/CourseSchedule.css
@@ -300,3 +300,19 @@
   font-weight: normal; /* Normal weight for issues */
   line-height: 1.5; /* Add spacing between lines for readability */
 }
+
+.export-button,
+.import-button {
+  padding: 8px;
+  font-size: 16px;
+  font-weight: bold;
+  width: 100%;
+  background-color: white;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: center;
+}
+
+
+


### PR DESCRIPTION
### Summary
This PR adds an export/import feature for the study plan, allowing users to save their current plan as a `.json` file and later load it back.

### Features
- Export button: Downloads the current study plan with a filename like `2025-mit-s1-ss.json`.
- Import button: Loads a previously exported plan and updates the UI accordingly.
- Consistent styling: Import/Export buttons are now aligned with other dropdown elements in the filter bar.

No backend changes were required for this feature.