### PR TITLE
Add suggestionbox module with suggestion logic

### DIFF
--- a/backend/api/suggestionbox/sugestionmds2024.py
+++ b/backend/api/suggestionbox/sugestionmds2024.py
@@ -1,0 +1,103 @@
+import os
+import xml.etree.ElementTree as ET
+
+# === Load XML files ===
+base_dir = os.path.dirname(os.path.abspath(__file__))
+ruleset_tree = ET.parse(os.path.join(base_dir, '../../config/ruleset.xml'))
+units_tree = ET.parse(os.path.join(base_dir, '../../config/units.xml'))
+
+ruleset_root = ruleset_tree.getroot()
+units_root = units_tree.getroot()
+
+# === Select MDS-2024 ruleset ===
+target_ruleset = None
+for rs in ruleset_root.findall(".//ruleset"):
+    if rs.findtext("code") == "MDS-2024":
+        target_ruleset = rs
+        break
+
+if target_ruleset is None:
+    raise ValueError("MDS-2024 ruleset not found.")
+
+def extract_required_units(section_code):
+    return {
+        code.strip()
+        for section in target_ruleset.findall(".//section")
+        if section.findtext("code") == section_code
+        for code in section.findtext("units", "").split(",")
+    }
+
+conversion_units = extract_required_units("conversion")
+core_units = extract_required_units("core")
+option_a_units = extract_required_units("optionA")
+
+# === Load unit attributes ===
+unit_points = {}
+for unit in units_root.findall(".//unit"):
+    code = unit.findtext("code")
+    point = int(unit.findtext("point", "6"))
+    unit_points[code] = point
+
+def get_unit_level(unit_code):
+    digits = ''.join(filter(str.isdigit, unit_code))
+    return int(digits[0]) if digits else None
+
+# === Main suggestion function ===
+def generate_suggestions_mds2024(student_timetable):
+    unit_to_semester = {}
+    for i, sem in enumerate(student_timetable):
+        for unit in sem:
+            if unit:
+                unit_to_semester[unit] = i  # map unit to semester index
+
+    suggestions = []
+
+    # ✅ 1. Conversion units taken too late
+    for unit in conversion_units:
+        if unit in unit_to_semester and unit_to_semester[unit] > 1:
+            suggestions.append(f"Consider taking {unit} earlier. Conversion units should be completed in your first year.")
+
+    # ✅ 2. Missing Python programming foundation
+    if "CITS1401" not in unit_to_semester and "CITS2401" not in unit_to_semester:
+        suggestions.append("Include a Python programming unit early (e.g., CITS1401) to support data analysis tasks.")
+
+    # ✅ 3. Recommend pairing ML with statistics
+    if "CITS5508" in unit_to_semester and not any(u in unit_to_semester for u in ["STAT4066", "STAT4064"]):
+        suggestions.append("Pair CITS5508 (Machine Learning) with a statistics unit like STAT4064 for better model evaluation skills.")
+
+    # ✅ 4. Data Wrangling unit too late
+    if "DATA5001" in unit_to_semester and unit_to_semester["DATA5001"] > 1:
+        suggestions.append("Move DATA5001 (Data Wrangling) earlier to build essential data handling skills.")
+
+    # ✅ 5. Project or capstone missing
+    if not any("capstone" in u.lower() or "project" in u.lower() for u in unit_to_semester):
+        suggestions.append("Include a project or or 3rd capstone unit in your final semester to demonstrate practical experience.")
+
+    # ✅ 6. Too many units in any semester (>3)
+    for i, sem in enumerate(student_timetable):
+        if len(sem) > 3:
+            suggestions.append(f"Semester {i+1} has a heavy load. Consider reducing to 3 units for academic balance.")
+            break
+
+    # === General MDS tips (fill to 15) ===
+    general = [
+        "Practice using real-world datasets from Kaggle or UCI Machine Learning Repository.",
+        "Build a portfolio of visualizations and dashboards using Python or Power BI.",
+        "Attend UWA Data Science Society events to network with peers and industry speakers.",
+        "Start a GitHub repo to document your Jupyter notebooks and class projects.",
+        "Learn cloud data tools like AWS, Azure, or GCP, which are widely used in data roles.",
+        "Apply for internships by your third semester through UWA Careers Centre.",
+        "Use UWA’s LinkedIn Learning access for R, SQL, Tableau, and big data tutorials."
+    ]
+
+    for tip in general:
+        if len(suggestions) < 15:
+            suggestions.append(tip)
+        else:
+            break
+
+    return {
+        "valid": True,
+        "suggestion_count": len(suggestions),
+        "suggestions": suggestions
+    }

--- a/backend/api/suggestionbox/sugestionmds2025.py
+++ b/backend/api/suggestionbox/sugestionmds2025.py
@@ -1,0 +1,103 @@
+import os
+import xml.etree.ElementTree as ET
+
+# === Load XML files ===
+base_dir = os.path.dirname(os.path.abspath(__file__))
+ruleset_tree = ET.parse(os.path.join(base_dir, '../../config/ruleset.xml'))
+units_tree = ET.parse(os.path.join(base_dir, '../../config/units.xml'))
+
+ruleset_root = ruleset_tree.getroot()
+units_root = units_tree.getroot()
+
+# === Select MDS-2025 ruleset ===
+target_ruleset = None
+for rs in ruleset_root.findall(".//ruleset"):
+    if rs.findtext("code") == "MDS-2025":
+        target_ruleset = rs
+        break
+
+if target_ruleset is None:
+    raise ValueError("MDS-2025 ruleset not found.")
+
+def extract_required_units(section_code):
+    return {
+        code.strip()
+        for section in target_ruleset.findall(".//section")
+        if section.findtext("code") == section_code
+        for code in section.findtext("units", "").split(",")
+    }
+
+conversion_units = extract_required_units("conversion")
+core_units = extract_required_units("core")
+option_a_units = extract_required_units("optionA")
+
+# === Load unit points ===
+unit_points = {}
+for unit in units_root.findall(".//unit"):
+    code = unit.findtext("code")
+    point = int(unit.findtext("point", "6"))
+    unit_points[code] = point
+
+def get_unit_level(unit_code):
+    digits = ''.join(filter(str.isdigit, unit_code))
+    return int(digits[0]) if digits else None
+
+# === MDS-2025 Suggestion Generator ===
+def generate_suggestions_mds2025(student_timetable):
+    unit_to_semester = {}
+    for i, sem in enumerate(student_timetable):
+        for unit in sem:
+            if unit:
+                unit_to_semester[unit] = i
+
+    suggestions = []
+
+    # ✅ 1. Conversion unit timing
+    for unit in conversion_units:
+        if unit in unit_to_semester and unit_to_semester[unit] > 1:
+            suggestions.append(f"Consider taking {unit} earlier. Conversion units should be completed in your first year.")
+
+    # ✅ 2. Recommend Python programming if missing
+    if not any(u in unit_to_semester for u in ["CITS1401", "CITS2401"]):
+        suggestions.append("Include a Python programming unit early (e.g., CITS1401) to build data science coding skills.")
+
+    # ✅ 3. Recommend pairing ML with statistics
+    if "CITS5508" in unit_to_semester and not any(u in unit_to_semester for u in ["STAT4064", "STAT4066"]):
+        suggestions.append("Pair CITS5508 (Machine Learning) with a statistics unit like STAT4064 for a more robust understanding.")
+
+    # ✅ 4. Warn if DATA5001 (Data Wrangling) is too late
+    if "DATA5001" in unit_to_semester and unit_to_semester["DATA5001"] > 1:
+        suggestions.append("Move DATA5001 (Data Wrangling) earlier to strengthen your foundations for future units.")
+
+    # ✅ 5. Suggest project/capstone inclusion
+    if not any("project" in u.lower() or "capstone" in u.lower() for u in unit_to_semester):
+        suggestions.append("Include a project or capstone unit in your final or 3rd semester to apply your learning practically.")
+
+
+    # ✅ 7. Check if Option A units are missing
+    option_a_selected = [u for u in unit_to_semester if u in option_a_units]
+    if len(option_a_selected) < 2:
+        suggestions.append("Add more Option A electives to broaden your technical exposure and meet graduation conditions.")
+
+    # === General Advice (fill to 15) ===
+    general = [
+        "Build a public GitHub profile with Jupyter notebooks and real dataset projects.",
+        "Practice EDA and visualization using seaborn, matplotlib, and Plotly.",
+        "Explore internships via the UWA Careers Centre from semester 3 onward.",
+        "Join the UWA Data Science Club for networking and workshops.",
+        "Attend industry events and conferences related to AI and analytics.",
+        "Learn cloud data tools like AWS S3, BigQuery, or Azure ML.",
+        "Use UWA’s free LinkedIn Learning access to take courses in SQL, Power BI, and TensorFlow."
+    ]
+
+    for tip in general:
+        if len(suggestions) < 15:
+            suggestions.append(tip)
+        else:
+            break
+
+    return {
+        "valid": True,
+        "suggestion_count": len(suggestions),
+        "suggestions": suggestions
+    }

--- a/backend/api/suggestionbox/sugestionmit2024.py
+++ b/backend/api/suggestionbox/sugestionmit2024.py
@@ -1,0 +1,97 @@
+import os
+import xml.etree.ElementTree as ET
+
+# Load XML files
+base_dir = os.path.dirname(os.path.abspath(__file__))
+ruleset_tree = ET.parse(os.path.join(base_dir, '../../config/ruleset.xml'))
+units_tree = ET.parse(os.path.join(base_dir, '../../config/units.xml'))
+
+ruleset_root = ruleset_tree.getroot()
+units_root = units_tree.getroot()
+
+# Parse ruleset
+target_ruleset = None
+for rs in ruleset_root.findall(".//ruleset"):
+    if rs.findtext("code") == "MIT-2024":
+        target_ruleset = rs
+        break
+
+def extract_required_units(section_code):
+    return {
+        code.strip()
+        for section in target_ruleset.findall(".//section")
+        if section.findtext("code") == section_code
+        for code in section.findtext("units", "").split(",")
+    }
+
+conversion_units = extract_required_units("conversion")
+core_units = extract_required_units("core")
+option_a_units = extract_required_units("optionA")
+
+# Load unit points
+unit_points = {}
+for unit in units_root.findall(".//unit"):
+    code = unit.findtext("code")
+    point = int(unit.findtext("point", "6"))
+    unit_points[code] = point
+
+def get_unit_level(unit_code):
+    digits = ''.join(filter(str.isdigit, unit_code))
+    return int(digits[0]) if digits else None
+
+# ✅ Pure function to generate suggestions (NO Flask)
+def generate_suggestions_mit2024(student_timetable):
+    unit_to_semester = {}
+    for i, sem in enumerate(student_timetable):
+        for unit in sem:
+            if unit:
+                unit_to_semester[unit] = i
+
+    suggestions = []
+    
+    for unit in conversion_units:
+        if unit in unit_to_semester and unit_to_semester[unit] > 1:
+            suggestions.append(f"Consider taking {unit} earlier. Conversion units are better completed in your first year.")
+    # Targeted suggestions
+    if "CITS5508" not in unit_to_semester:
+        suggestions.append("CITS5508 (Machine Learning) is great for a career in data science or AI roles.")
+
+    for unit in conversion_units:
+        if unit in unit_to_semester and unit_to_semester[unit] > 1:
+            suggestions.append(f"Consider taking {unit} earlier. Conversion units are better completed in your first year.")
+
+    if "CITS5508" in unit_to_semester and "CITS5017" not in unit_to_semester:
+        suggestions.append("CITS5017 (Deep Learning) builds on Machine Learning and strengthens your AI track.")
+
+
+    if "CITS5505" in unit_to_semester and unit_to_semester["CITS5505"] > 3:
+        suggestions.append("Take CITS5505 (Agile Web Development) earlier to apply agile skills in later units.")
+
+    if "PHIL4100" in unit_to_semester and unit_to_semester["PHIL4100"] < 3:
+        suggestions.append("PHIL4100 (Ethics) is best taken in the final year when you can reflect critically.")
+
+    if "CITS5206" in unit_to_semester and unit_to_semester["CITS5206"] < 3:
+        suggestions.append("CITS5206 (Capstone) should be in your final year to reflect your full learning journey.")
+
+    # General tips (fill to 15 suggestions)
+    general = [
+        "Start a GitHub portfolio with your project code. Employers value real examples.",
+        "Apply for internships by semester 3 to gain industry experience before graduating.",
+        "Join clubs like UWA AI Society or Data Science Club to build connections.",
+        "Attend UWA tech meetups and industry events for networking and exposure.",
+        "Use UWA’s LinkedIn Learning access for free certifications in Python, AI, and cloud.",
+        "Review your plan with a course adviser each year to ensure compliance and balance.",
+        "Always keep a list of backup electives in case your preferred units are unavailable."
+    ]
+
+    for tip in general:
+        if len(suggestions) < 15:
+            suggestions.append(tip)
+        else:
+            break
+
+    return {
+        "valid": True,
+        "suggestion_count": len(suggestions),
+        "suggestions": suggestions
+    }

--- a/backend/api/suggestionbox/sugestionmit2025.py
+++ b/backend/api/suggestionbox/sugestionmit2025.py
@@ -1,0 +1,97 @@
+import os
+import xml.etree.ElementTree as ET
+
+# Load XML files
+base_dir = os.path.dirname(os.path.abspath(__file__))
+ruleset_tree = ET.parse(os.path.join(base_dir, '../../config/ruleset.xml'))
+units_tree = ET.parse(os.path.join(base_dir, '../../config/units.xml'))
+
+ruleset_root = ruleset_tree.getroot()
+units_root = units_tree.getroot()
+
+# Parse MIT-2025 ruleset
+target_ruleset = None
+for rs in ruleset_root.findall(".//ruleset"):
+    if rs.findtext("code") == "MIT-2025":  # CHANGED for MIT-2025
+        target_ruleset = rs
+        break
+
+if target_ruleset is None:
+    raise ValueError("MIT-2025 ruleset not found.")
+
+def extract_required_units(section_code):
+    return {
+        code.strip()
+        for section in target_ruleset.findall(".//section")
+        if section.findtext("code") == section_code
+        for code in section.findtext("units", "").split(",")
+    }
+
+conversion_units = extract_required_units("conversion")
+core_units = extract_required_units("core")
+option_a_units = extract_required_units("optionA")
+
+# Load unit points
+unit_points = {}
+for unit in units_root.findall(".//unit"):
+    code = unit.findtext("code")
+    point = int(unit.findtext("point", "6"))
+    unit_points[code] = point
+
+def get_unit_level(unit_code):
+    digits = ''.join(filter(str.isdigit, unit_code))
+    return int(digits[0]) if digits else None
+
+# ✅ Pure suggestion function for MIT-2025
+def generate_suggestions_mit2025(student_timetable):
+    unit_to_semester = {}
+    for i, sem in enumerate(student_timetable):
+        for unit in sem:
+            if unit:
+                unit_to_semester[unit] = i
+
+    suggestions = []
+
+    # Conversion unit timing advice
+    for unit in conversion_units:
+        if unit in unit_to_semester and unit_to_semester[unit] > 1:
+            suggestions.append(f"Consider taking {unit} earlier. Conversion units are better completed in your first year.")
+
+    # Targeted suggestions
+    if "CITS5508" not in unit_to_semester:
+        suggestions.append("CITS5508 (Machine Learning) is great for a career in data science or AI roles.")
+
+    if "CITS5508" in unit_to_semester and "CITS5017" not in unit_to_semester:
+        suggestions.append("CITS5017 (Deep Learning) builds on Machine Learning and strengthens your AI track.")
+
+    if "CITS5505" in unit_to_semester and unit_to_semester["CITS5505"] > 3:
+        suggestions.append("Take CITS5505 (Agile Web Development) earlier to apply agile skills in later units.")
+
+    if "PHIL4100" in unit_to_semester and unit_to_semester["PHIL4100"] < 3:
+        suggestions.append("PHIL4100 (Ethics) is best taken in the final year when you can reflect critically.")
+
+    if "CITS5206" in unit_to_semester and unit_to_semester["CITS5206"] < 3:
+        suggestions.append("CITS5206 (Capstone) should be in your final year to reflect your full learning journey.")
+
+    # General suggestions (to reach 15)
+    general = [
+        "Start a GitHub portfolio with your project code. Employers value real examples.",
+        "Apply for internships by semester 3 to gain industry experience before graduating.",
+        "Join clubs like UWA AI Society or Data Science Club to build connections.",
+        "Attend UWA tech meetups and industry events for networking and exposure.",
+        "Use UWA’s LinkedIn Learning access for free certifications in Python, AI, and cloud.",
+        "Review your plan with a course adviser each year to ensure compliance and balance.",
+        "Always keep a list of backup electives in case your preferred units are unavailable."
+    ]
+
+    for tip in general:
+        if len(suggestions) < 15:
+            suggestions.append(tip)
+        else:
+            break
+
+    return {
+        "valid": True,
+        "suggestion_count": len(suggestions),
+        "suggestions": suggestions
+    }

--- a/backend/api/suggestionbox/testsug.py
+++ b/backend/api/suggestionbox/testsug.py
@@ -1,0 +1,62 @@
+# Remove mock function overrides and rely on real imported suggestion functions
+from sugestionmit2024 import generate_suggestions_mit2024
+from sugestionmit2025 import generate_suggestions_mit2025
+from sugestionmds2024 import generate_suggestions_mds2024
+from sugestionmds2025 import generate_suggestions_mds2025
+
+# Define test plans
+test_plans = {
+    "MIT-2024": [
+        ["CITS1401", "CITS1003"],
+        ["CITS1402", "CITS2005"],
+        ["CITS5508"],
+        ["CITS5206"]
+    ],
+    "MIT-2025": [
+        ["CITS1401"],
+        ["CITS1402", "CITS5508"],
+        ["CITS5505"],
+        ["PHIL4100"]
+    ],
+    "MDS-2024": [
+        ["DATA5001", "CITS1401"],
+        ["CITS5508", "STAT4064"],
+        ["CITS5206", "DATA5100"],
+        ["PHIL4100"]
+    ],
+    "MDS-2025": [
+        ["DATA5001", "CITS1402"],
+        ["STAT4066"],
+        ["CITS5508"],
+        ["PHIL4100"]
+    ]
+}
+
+# Store results
+test_results = []
+
+# Execute test cases
+for label, plan in test_plans.items():
+    if label == "MIT-2024":
+        result = generate_suggestions_mit2024(plan)
+    elif label == "MIT-2025":
+        result = generate_suggestions_mit2025(plan)
+    elif label == "MDS-2024":
+        result = generate_suggestions_mds2024(plan)
+    elif label == "MDS-2025":
+        result = generate_suggestions_mds2025(plan)
+    else:
+        result = {"label": label, "suggestions": ["No function defined."]}
+
+    test_results.append({
+        "Program": label,
+        "Total Suggestions": len(result["suggestions"]),
+        "Details": result["suggestions"]
+    })
+
+import pandas as pd
+
+df = pd.DataFrame(test_results)
+print("\n=== Program Suggestion Test Results ===")
+print(df.to_string(index=False))
+

--- a/backend/config/units.xml
+++ b/backend/config/units.xml
@@ -86,10 +86,6 @@
                                 </condition>
                             </conditions>
                         </conditionGroup>
-                        <condition>
-                            <type>Unit</type>
-                            <unit>STAT2062</unit>
-                        </condition>
                     </conditions>
                 </conditionGroup>
             </conditions>
@@ -167,7 +163,7 @@
         <code>STAT2401</code>
         <point>6</point>
         <name>Analysis of Experiments</name>
-        <availability>24S1</availability>
+        <availability>24S1,25S1</availability>
 
         <prerequisites>
             <!-- Refer to a pre-defined ConditionGroup -->
@@ -179,7 +175,7 @@
         <code>STAT2402</code>
         <point>6</point>
         <name>Analysis of Observations</name>
-        <availability>24S1</availability>
+        <availability>24S2,25S2</availability>
 
         <prerequisites>
             <!-- Refer to a pre-defined ConditionGroup -->
@@ -288,7 +284,7 @@
         <code>STAT4066</code>
         <point>6</point>
         <name>Bayesian Computing and Statistics</name>
-        <availability>25S2</availability>
+        <availability>24S2,25S2</availability>
 
         <prerequisites>
             <conditionGroup ref="STAT4066Prereq"/>


### PR DESCRIPTION
This pull request introduces the `suggestionbox` module located under `backend/api/suggestionbox/`.

✨ Features:
- Supports study plan suggestions for:
  - MIT 2024 and 2025 rulesets
  - MDS 2024 and 2025 rulesets
- Generates tailored academic recommendations based on unit timing, prerequisites, and course structure

This feature enhances backend support for advising students on unit planning and sequencing.
